### PR TITLE
* foreach 错别字

### DIFF
--- a/19.2.md
+++ b/19.2.md
@@ -18,7 +18,7 @@ gcc -I /usr/local/php-dev/include/php/ \	-I /usr/local/php-dev/include/php/main
 CC = gccCFLAGS = -c \    -I /usr/local/php-dev/include/php/ \    -I /usr/local/php-dev/include/php/main/ \    -I /usr/local/php-dev/include/php/Zend/ \    -I /usr/local/php-dev/include/php/TSRM/ \    -Wall -gLDFLAGS = -lphp5all: embed1.c    $(CC) -o embed1.o embed1.c $(CFLAGS)    $(CC) -o embed1 embed1.o $(LDFLAGS)
 ````
 
-这个Makefile和前面提供的命令有⼀些重要的区别. 首先, 它用-Wall开关打开了编译期的警 告, 并且用-g打开了调试信息. 此外它将编译和链接两个阶段分为了两个独立的阶段, 这样在后期 增加更多源文件的时候就相对容易. 请自己重新组着这个Makefile, 不过这里用于对齐的是Tab(水 平制表符)而不是空格.
+这个Makefile和前面提供的命令有⼀些重要的区别. 首先, 它用-Wall开关打开了编译期的警 告, 并且用-g打开了调试信息. 此外它将编译和链接两个阶段分为了两个独立的阶段, 这样在后期 增加更多源文件的时候就相对容易. 请自己重新组装这个Makefile, 不过这里用于对齐的是Tab(水 平制表符)而不是空格.
 
 现在, 你对embed1.c源文件做修改后, 只需要执行⼀一个make命令就可以构建出新的 embed1可执行程序了.
 

--- a/8.2.md
+++ b/8.2.md
@@ -271,7 +271,7 @@ void merge_associative(HashTable *target, HashTable *source)
 ````
 ### 遍历
 
-在PHP语言中，我们有很多方法来遍历一个数组，对于数组的本质HashTable，我们也有很多办法来对其进行遍历操作。首先最简单的一种办法便是使用一种与PHP语言中forech语句功能类似的函数——zend_hash_apply，它接收一个回调函数，并将HashTable的每一个元素都传递给它。
+在PHP语言中，我们有很多方法来遍历一个数组，对于数组的本质HashTable，我们也有很多办法来对其进行遍历操作。首先最简单的一种办法便是使用一种与PHP语言中foreach语句功能类似的函数——zend_hash_apply，它接收一个回调函数，并将HashTable的每一个元素都传递给它。
 ````c
 typedef int (*apply_func_t)(void *pDest TSRMLS_DC);
 void zend_hash_apply(HashTable *ht,apply_func_t apply_func TSRMLS_DC);
@@ -293,14 +293,14 @@ void zend_hash_apply_with_argument(HashTable *ht,apply_func_arg_t apply_func, vo
 表格 8.1. 回调函数的返回值
 Constant						Meaning
 
-ZEND_HASH_APPLY_KEEP		结束当前请求，进入下一个循环。与PHP语言forech语句中的一次循环执行完毕或者遇到continue关键字的作用一样。
-ZEND_HASH_APPLY_STOP		跳出，与PHP语言forech语句中的break关键字的作用一样。
+ZEND_HASH_APPLY_KEEP		结束当前请求，进入下一个循环。与PHP语言foreach语句中的一次循环执行完毕或者遇到continue关键字的作用一样。
+ZEND_HASH_APPLY_STOP		跳出，与PHP语言foreach语句中的break关键字的作用一样。
 ZEND_HASH_APPLY_REMOVE		删除当前的元素，然后继续处理下一个。相当于在PHP语言中：unset($foo[$key]);continue;
 
 
 ````
 
-我们来一下PHP语言中的forech循环：
+我们来一下PHP语言中的foreach循环：
 
 ````php
 <?php
@@ -456,7 +456,7 @@ int zend_hash_has_more_elements(HashTable *ht);
 ````
 
 	<div class="tip-common">PHP语言中的next()、prev()、end()函数在移动完指针之后，都通过调用zend_hash_get_current_data()函数来获取当前所指的元素并返回。而each()虽然和next()很像，却是使用zend_hash_get_current_key()函数的返回值来作为它的返回值。</div>
-现在我们用另外一种方法来实现上面的forech：
+现在我们用另外一种方法来实现上面的foreach：
 ````c
 void php_sample_print_var_hash(HashTable *arrht)
 {


### PR DESCRIPTION
8.2md 中部分的 `foreach` 写成 `forech` 了， 